### PR TITLE
Fix documentation issues from UDP module

### DIFF
--- a/library/socket.lua
+++ b/library/socket.lua
@@ -955,6 +955,16 @@ function udp_generic:settimeout(timeout) end
 ---
 ---Note: Before the choice between IPv4 and IPv6 happens, the internal socket object is invalid and therefore setoption will fail.
 ---
+---### To mark a socket as connected or unconnected use `---@cast`. Example:
+---```lua
+---local server, err = socket.udp()
+---local client, err = socket.udp()
+------@cast server UDPSocketUnconnected
+---server:setsockname("127.0.0.1", 12345)
+------@cast client UDPSocketConnected
+---client:setpeername("127.0.0.1", 12345)
+---```
+---
 ---@return (UDPSocketConnected | UDPSocketUnconnected)?, SocketReturnError
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
@@ -964,6 +974,16 @@ function socket.udp() end
 ---Creates and returns an unconnected IPv4 UDP object. Unconnected objects support the sendto, receive, receivefrom, getoption, getsockname, setoption, settimeout, setpeername, setsockname, and close. The setpeername is used to connect the object.
 ---
 ---In case of success, a new unconnected UDP object returned. In case of error, nil is returned, followed by an error message.
+---
+---### To mark a socket as connected or unconnected use `---@cast`. Example:
+---```lua
+---local server, err = socket.udp4()
+---local client, err = socket.udp4()
+------@cast server UDPSocketUnconnected
+---server:setsockname("127.0.0.1", 12345)
+------@cast client UDPSocketConnected
+---client:setpeername("127.0.0.1", 12345)
+---```
 ---
 ---@return (UDPSocketConnected | UDPSocketUnconnected)?, SocketReturnError
 ---
@@ -976,6 +996,16 @@ function socket.udp4() end
 ---In case of success, a new unconnected UDP object returned. In case of error, nil is returned, followed by an error message.
 ---
 ---Note: The UDP object returned will have the option "ipv6-v6only" set to true.
+---
+---### To mark a socket as connected or unconnected use `---@cast`. Example:
+---```lua
+---local server, err = socket.udp6()
+---local client, err = socket.udp6()
+------@cast server UDPSocketUnconnected
+---server:setsockname("127.0.0.1", 12345)
+------@cast client UDPSocketConnected
+---client:setpeername("127.0.0.1", 12345)
+---```
 ---
 ---@return (UDPSocketConnected | UDPSocketUnconnected)?, SocketReturnError
 ---

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -308,6 +308,7 @@ socket._VERSION = ""
 ---{{{ Common Types
 --#region Common Types
 
+---A string representing a datagram
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 ---@alias Datagram string
@@ -318,12 +319,19 @@ socket._VERSION = ""
 -->       Sometimes its 1 and 2, others up to 3.
 
 ---
----😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
----@alias SocketReturnResult 1? # Returns 1 on success
+---A 1 in case of success
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
----@alias SocketReturnError string? # If operation fails, returns an error message
+---@alias SocketReturnResult 1?
 
+---
+---Error message in case of failure
+---
+---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
+---@alias SocketReturnError string?
+
+---
+---A string with the family ("inet" or "inet6")
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 ---@alias SocketFamily

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -930,7 +930,7 @@ function udp_generic:settimeout(timeout) end
 ---
 ---Note: Before the choice between IPv4 and IPv6 happens, the internal socket object is invalid and therefore setoption will fail.
 ---
----@return UDPSocketGeneric
+---@return UDPSocketConnected | UDPSocketUnconnected
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function socket.udp() end
@@ -940,7 +940,7 @@ function socket.udp() end
 ---
 ---In case of success, a new unconnected UDP object returned. In case of error, nil is returned, followed by an error message.
 ---
----@return UDPSocketGeneric
+---@return UDPSocketConnected | UDPSocketUnconnected
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function socket.udp4() end
@@ -952,7 +952,7 @@ function socket.udp4() end
 ---
 ---Note: The TCP object returned will have the option "ipv6-v6only" set to true.
 ---
----@return UDPSocketGeneric
+---@return UDPSocketConnected | UDPSocketUnconnected
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function socket.udp6() end

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -305,6 +305,36 @@ function socket.try(...) end
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 socket._VERSION = ""
 
+---{{{ Common Types
+--#region Common Types
+
+---
+---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
+---@alias Datagram string
+
+--> Note: In some functions, there could be more results than just a 1,
+-->       but the documentation has no information as to what each of them are.
+-->       Check: https://github.com/lunarmodules/luasocket/blob/master/src/udp.c#L253
+-->       Sometimes its 1 and 2, others up to 3.
+
+---
+---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
+---@alias SocketReturnResult 1? # Returns 1 on success
+---
+---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
+---@alias SocketReturnError string? # If operation fails, returns an error message
+
+---
+---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
+---@alias SocketFamily
+---| "inet" IPv4
+---| "inet6" IPv6
+---| "unspec" Unspecified
+---| "unknown" Unknown
+
+--#endregion Common Types
+---}}}
+
 --{{{ TCP
 --#region TCP
 
@@ -434,13 +464,6 @@ function tcp_client:getoption(option) end
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function tcp_server:getoption(option) end
-
----😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
----@alias SocketFamily
----| "inet" IPv4
----| "inet6" IPv6
----| "unspec" Unspecified
----| "unknown" Unknown
 
 ---
 ---Returns information about the remote side of a connected client object.

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -708,16 +708,6 @@ function socket.tcp6() end
 --{{{ UDP
 --#region UDP
 
----
----😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
----@alias Datagram string
-
----
----😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
----@alias inetFamily
----| "inet" IPv4
----| "inet6" IPv6
-
 --> Generic is my way to avoid stating the same thing twice.
 --> Means that both connected and unconnected have it.
 

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -748,7 +748,7 @@ function udp_generic:close() end
 ---| 'ip-drop-membership': Leaves the multicast group specified. Receives a table with fields multiaddr and interface, each containing an IP address.
 
 ---
----Gets an option value from the UDP object. See `setoption` for description of the option names and values.
+---Gets an option value from the UDP object.
 ---
 ---Option is a string with the option name.
 ---
@@ -760,6 +760,10 @@ function udp_generic:close() end
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_generic:getoption(option) end
+
+--> Note: This is not very satisfying, since one could check
+-->       if the first argument is nil. But LuaLS will want to
+-->       check the rest of the arguments anyway.
 
 ---
 ---Retrieves information about the peer associated with a connected UDP object.
@@ -964,7 +968,7 @@ function socket.udp4() end
 ---
 ---In case of success, a new unconnected UDP object returned. In case of error, nil is returned, followed by an error message.
 ---
----Note: The TCP object returned will have the option "ipv6-v6only" set to true.
+---Note: The UDP object returned will have the option "ipv6-v6only" set to true.
 ---
 ---@return (UDPSocketConnected | UDPSocketUnconnected)?, SocketReturnError
 ---

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -877,7 +877,7 @@ function udp_generic:setoption(option, value) end
 ---
 ---@return UDPSocketConnected
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
-function udp_unconnected:setpeername(address, port) end
+function udp_generic:setpeername(address, port) end
 
 ---
 ---Changes the peer of a UDP object. This method turns an unconnected UDP object into a connected UDP object or vice versa.
@@ -896,7 +896,7 @@ function udp_unconnected:setpeername(address, port) end
 ---
 ---@return UDPSocketUnconnected
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
-function udp_connected:setpeername(address) end
+function udp_generic:setpeername(address) end
 
 ---
 ---Binds the UDP object to a local address.

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -756,7 +756,7 @@ function udp_generic:close() end
 ---
 ---@param option UDPOption
 ---
----@return any | nil, nil | string
+---@return any?, SocketReturnError
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_generic:getoption(option) end
@@ -768,8 +768,7 @@ function udp_generic:getoption(option) end
 ---
 ---Note: It makes no sense to call this method on unconnected objects.
 ---
----@return string, number, inetFamily
----
+---@return string?, number?, SocketFamily?
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_connected:getpeername() end
 
@@ -780,7 +779,7 @@ function udp_connected:getpeername() end
 ---
 ---Note: UDP sockets are not bound to any address until the `setsockname` or the `sendto` method is called for the first time (in which case it is bound to an ephemeral port and the wild-card address).
 ---
----@return string, number, inetFamily
+---@return string?, number?, SocketFamily?
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_generic:getsockname() end
@@ -806,7 +805,7 @@ function udp_generic:gettimeout() end
 ---
 ---@param size number?
 ---
----@return string? datagram
+---@return Datagram? datagram
 ---
 ---@return 'timeout'? err # `'timeout'` in case of timeout
 ---
@@ -816,7 +815,7 @@ function udp_generic:receive(size) end
 ---Works exactly as the `receive` method, except it returns the IP address and port as extra return values (and is therefore slightly less efficient)
 ---@param size number?
 ---
----@return string? datagram
+---@return Datagram? datagram
 ---@return string | 'timeout' ip_or_err # IP address or `'timeout'` error string
 ---@return number port
 ---
@@ -831,9 +830,9 @@ function udp_unconnected:receivefrom(size) end
 ---If successful, the method returns `1`. In case of error, the method returns `nil` followed by an `error message`.
 ---
 ---Note: In UDP, the send method never blocks and the only way it can fail is if the underlying transport layer refuses to send a message to the specified address (i.e. no interface accepts the address).
----@param datagram string
+---@param datagram Datagram
 ---
----@return number?, string error
+---@return SocketReturnResult, SocketReturnError
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_connected:send(datagram) end
 
@@ -846,11 +845,11 @@ function udp_connected:send(datagram) end
 ---
 ---Note: In UDP, the send method never blocks and the only way it can fail is if the underlying transport layer refuses to send a message to the specified address (i.e. no interface accepts the address).
 ---
----@param datagram string
+---@param datagram Datagram
 ---@param ip string
 ---@param port number
 ---
----@return number?, string error
+---@return SocketReturnResult, SocketReturnError
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_unconnected:sendto(datagram, ip, port) end
 
@@ -866,6 +865,7 @@ function udp_unconnected:sendto(datagram, ip, port) end
 ---@param option UDPOption
 ---@param value any?
 ---
+---@return SocketReturnResult, SocketReturnError
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_generic:setoption(option, value) end
 
@@ -888,7 +888,7 @@ function udp_generic:setoption(option, value) end
 ---@param address string # can be a host name
 ---@param port number
 ---
----@return UDPSocketConnected
+---@return SocketReturnResult, SocketReturnError
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_generic:setpeername(address, port) end
 
@@ -907,7 +907,7 @@ function udp_generic:setpeername(address, port) end
 ---
 ---@param address "*" # will turn it unconnected
 ---
----@return UDPSocketUnconnected
+---@return SocketReturnResult, SocketReturnError
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_generic:setpeername(address) end
 
@@ -920,6 +920,7 @@ function udp_generic:setpeername(address) end
 ---
 ---Note: This method can only be called before any datagram is sent through the UDP object, and only once. Otherwise, the system automatically binds the object to all local interfaces and chooses an ephemeral port as soon as the first datagram is sent. After the local address is set, either automatically by the system or explicitly by setsockname, it cannot be changed.
 ---
+---@return SocketReturnResult, SocketReturnError
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function udp_unconnected:setsockname(address, port) end
 
@@ -943,7 +944,7 @@ function udp_generic:settimeout(timeout) end
 ---
 ---Note: Before the choice between IPv4 and IPv6 happens, the internal socket object is invalid and therefore setoption will fail.
 ---
----@return UDPSocketConnected | UDPSocketUnconnected
+---@return (UDPSocketConnected | UDPSocketUnconnected)?, SocketReturnError
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function socket.udp() end
@@ -953,7 +954,7 @@ function socket.udp() end
 ---
 ---In case of success, a new unconnected UDP object returned. In case of error, nil is returned, followed by an error message.
 ---
----@return UDPSocketConnected | UDPSocketUnconnected
+---@return (UDPSocketConnected | UDPSocketUnconnected)?, SocketReturnError
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function socket.udp4() end
@@ -965,7 +966,7 @@ function socket.udp4() end
 ---
 ---Note: The TCP object returned will have the option "ipv6-v6only" set to true.
 ---
----@return UDPSocketConnected | UDPSocketUnconnected
+---@return (UDPSocketConnected | UDPSocketUnconnected)?, SocketReturnError
 ---
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
 function socket.udp6() end

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -934,7 +934,7 @@ function udp_generic:setpeername(address) end
 ---
 ---@return SocketReturnResult, SocketReturnError
 ---😱 [Types](https://github.com/LuaCATS/luasocket/blob/main/library/socket.lua) incomplete or incorrect? 🙏 [Please contribute!](https://github.com/LuaCATS/luasocket/pulls)
-function udp_unconnected:setsockname(address, port) end
+function udp_generic:setsockname(address, port) end
 
 ---
 ---Sets the timeout value for the socket

--- a/library/socket.lua
+++ b/library/socket.lua
@@ -743,6 +743,7 @@ local udp_unconnected = {}
 function udp_generic:close() end
 
 ---
+---The option descriptions come from the official documentation, which come from the man pages.
 ---@alias UDPOption
 ---| 'dontroute': Indicates that outgoing messages should bypass the standard routing facilities. Receives a boolean value;
 ---| 'broadcast': Requests permission to send broadcast datagrams on the socket. Receives a boolean value;
@@ -871,8 +872,6 @@ function udp_unconnected:sendto(datagram, ip, port) end
 ---Option is a string with the option name, and value depends on the option being set
 ---
 ---The method returns 1 in case of success, or nil followed by an error message otherwise.
----
----Note: The descriptions above come from the official documentation, which come from the man pages.
 ---
 ---@param option UDPOption
 ---@param value any?


### PR DESCRIPTION
The changes are in the commit names. But from memory:

1.`luasocket` actually returns a number and an string for most of the functions. Made sure to add all the extra returns as per the documentation
2. Moved some of the types as `Common types`. Because those are types that both TCP and UDP share. I planned on changing the TCP one to use these more readable types (they are just aliases, but makes it easier to read when creating these type annotations)
 3. Changed the constructor function since it was returning a `generic` instead of `unconnected | connected`. I don't think there's any way I can change the type of the socket from `unconnected` to `connected` because of how it works. It doesn't return the new class, it just modifies the state of a current socket
 4. Corrected some grammatical errors and wrong statements from the official documentation. (For instance, it says that only connected sockets can do `:setpeername("*")` when actually both connected and unconnected sockets can do so)
 
 I've currently set this as a draft since I haven't tried everything. And I'd like to make sure they work before pushing to the main branch.
 
 I'd also like insights regarding how I made constructors. Specifically `socket.udp()`. 